### PR TITLE
Add auth for noaa_cron.php

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -17,6 +17,14 @@ RUN docker-php-ext-install mysqli && docker-php-ext-enable mysqli
 # Use the default production configuration that ships with the docker image
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
+# Make the HTTP Authorization header available to PHP
+RUN { \
+    echo '<Directory /var/www/html>'; \
+    echo '  SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1'; \
+    echo '</Directory>'; \
+} > /etc/apache2/conf-available/pass-authorization.conf \
+    && a2enconf pass-authorization
+
 COPY src /var/www/src/
 COPY public_html/ /var/www/html/
 

--- a/cron/takeasweater.sh
+++ b/cron/takeasweater.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -ex
-curl ${TAKEASWEATER_URL}/noaa_cron.php
+curl -H "Authorization: Bearer ${TAKEASWEATER_CRON_SECRET}" ${TAKEASWEATER_URL}/noaa_cron.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - DB_USER=takeasweater
       - DB_PASSWORD=takeasweater
       - DB_NAME=takeasweater
+      - TAKEASWEATER_CRON_SECRET=${TAKEASWEATER_CRON_SECRET:-cronSecret123}
     volumes:
       - ./public_html:/var/www/html
       - ./src:/var/www/src
@@ -25,8 +26,11 @@ services:
       dockerfile: Dockerfile.cron
       args:
         ENV: dev
+    env_file:
+      - .env
     environment:
       - TAKEASWEATER_URL=http://web
+      - TAKEASWEATER_CRON_SECRET=${TAKEASWEATER_CRON_SECRET:-cronSecret123}
     depends_on:
       - web
 

--- a/public_html/noaa_cron.php
+++ b/public_html/noaa_cron.php
@@ -5,6 +5,17 @@ require_once('../src/config.php');
 require_once('../src/classes/db.php');
 require_once('../src/classes/ndfdSOAPclientByDay.php');
 
+$http_authorization = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+$token = "";
+if (preg_match('/Bearer\s(\S+)/', $http_authorization, $matches)) {
+    $token = $matches[1];
+}
+if(empty($token) || $token != TAKEASWEATER_CRON_SECRET) {
+    header('HTTP/1.0 401 Unauthorized');
+    echo "Unauthorized.";
+    exit;
+}
+
 $webpage = new WTWebpage();
 
 $link = $webpage->getDbh();

--- a/src/config.php
+++ b/src/config.php
@@ -31,3 +31,6 @@ define('CONFIG_PRECISION', getenv('CONFIG_PRECISION') ? getenv('CONFIG_PRECISION
 
 // See also: http://api.openweathermap.org/
 define('OPENWEATHERMAP_API_KEY', getenv('OPENWEATHERMAP_API_KEY') ? getenv('OPENWEATHERMAP_API_KEY') : '');
+
+/** Used to authorize requests to noaa_cron.php */
+define('TAKEASWEATER_CRON_SECRET', getenv('TAKEASWEATER_CRON_SECRET') ? getenv('TAKEASWEATER_CRON_SECRET') : '');


### PR DESCRIPTION
This PR adds auth to the `noaa_cron.php` script so that only authorized cron requests will be allowed. 