### PR TITLE
Improve query performance

### DIFF
--- a/db/01_schema.sql
+++ b/db/01_schema.sql
@@ -59,6 +59,9 @@ create table takeasweater.noaa_weather
 create index forecast_create_date
     on takeasweater.noaa_weather (forecast_create_date);
 
+create index location_forecast_create_time
+    on takeasweater.noaa_weather (location_code, forecast_create_date, time_retrieved);
+
 create index forecast_days_out
     on takeasweater.noaa_weather (forecast_days_out);
 
@@ -212,4 +215,3 @@ create table takeasweater.wind_codes
 )
     engine = MyISAM
     charset = utf8mb3;
-


### PR DESCRIPTION
This PR improves the query performance when getting the predicted temperatures for a particular date (current or past).

## Changes

- Replaced correlated sub-queries with [CTEs](https://dev.mysql.com/doc/refman/8.4/en/with.html) (i.e. `WITH` syntax) to get the latest time more efficiently. Correlated sub-queries are executed for every row which is slow for large tables like `noaa_weather`.
- Added index on the `location_code`, `forecast_create_date`, and `time_retrieved` to further improve performance.
- Switched from using quoted strings to php [nowdocs](https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc) for better readability.



